### PR TITLE
Add logging_config test

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,35 @@
+import importlib
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def test_setup_logging_adds_handlers(monkeypatch):
+    # Ensure project root is on sys.path for module imports
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
+
+    # Provide a stub for python-dotenv so config.settings can be imported
+    sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+
+    import utils.logging_config as logging_config
+    importlib.reload(logging_config)
+
+    # Remove existing handlers so basicConfig attaches ours
+    root_logger = logging.getLogger()
+    old_handlers = root_logger.handlers[:]
+    root_logger.handlers.clear()
+
+    monkeypatch.setattr(logging_config, "LOG_LEVEL", "DEBUG")
+
+    logger = logging_config.setup_logging()
+
+    try:
+        assert logger.level == logging.DEBUG
+        handler_types = {type(h) for h in root_logger.handlers}
+        assert logging.FileHandler in handler_types
+        assert logging.StreamHandler in handler_types
+    finally:
+        root_logger.handlers[:] = old_handlers


### PR DESCRIPTION
## Summary
- add a test that verifies handlers and log level in `setup_logging`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_687f13095cb083329510c30a3574baf0