### PR TITLE
Fix remote SSH script variable expansion

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,7 +139,7 @@ jobs:
         scp -o StrictHostKeyChecking=no docker-compose.yml root@$DROPLET_IP:/root/
         
         # Deploy application
-        ssh -o StrictHostKeyChecking=no root@$DROPLET_IP << 'EOF'
+        ssh -o StrictHostKeyChecking=no root@$DROPLET_IP << EOF
           # Install Docker if not installed
           if ! command -v docker &> /dev/null; then
             curl -fsSL https://get.docker.com -o get-docker.sh
@@ -148,12 +148,12 @@ jobs:
           
           # Install Docker Compose if not installed
           if ! command -v docker-compose &> /dev/null; then
-            curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-\$(uname -s)-\$(uname -m)" -o /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
           fi
           
           # Login to DigitalOcean registry
-          doctl registry docker-config | docker login registry.digitalocean.com --username $(doctl account get --format Email --no-header) --password-stdin
+          doctl registry docker-config | docker login registry.digitalocean.com --username \$(doctl account get --format Email --no-header) --password-stdin
           
           # Create .env file
           cat > .env << ENVEOF


### PR DESCRIPTION
## Summary
- allow GitHub secrets to expand in SSH here-doc
- escape command substitutions so they run on the droplet

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6887381fb6108332ac2af9bf7bb2bb4e