### PR TITLE
Add permissions for security scan

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -191,7 +191,10 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: test
-    
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant minimal permissions for security scanning job

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68873ad116588332b2e32654047cac21