### PR TITLE
Add pandas dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "psycopg2-binary>=2.9.9",
     "mysql-connector-python>=8.3.0",
+    "pandas>=2.2.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- add `pandas` 2.2.2 to project dependencies

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688cda75b33c8332a284cabd7b2f9459